### PR TITLE
check for undefined part.body before trying to decode it.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,24 +69,26 @@ module.exports = function parseMessage(response) {
     var isHtml = part.mimeType && part.mimeType.indexOf('text/html') !== -1;
     var isPlain = part.mimeType && part.mimeType.indexOf('text/plain') !== -1;
     var isAttachment = headers['content-disposition'] && headers['content-disposition'].indexOf('attachment') !== -1;
-
-    if (isHtml && !isAttachment) {
-      result.textHtml = urlB64Decode(part.body.data);
-    } else if (isPlain && !isAttachment) {
-      result.textPlain = urlB64Decode(part.body.data);
-    } else if (isAttachment) {
-      var body = part.body;
-      if(!result.attachments) {
-        result.attachments = [];
+    
+    if (part.body) {
+      if (isHtml && !isAttachment) {
+        result.textHtml = urlB64Decode(part.body.data);
+      } else if (isPlain && !isAttachment) {
+        result.textPlain = urlB64Decode(part.body.data);
+      } else if (isAttachment) {
+        var body = part.body;
+        if(!result.attachments) {
+          result.attachments = [];
+        }
+        result.attachments.push({
+          filename: part.filename,
+          mimeType: part.mimeType,
+          size: body.size,
+          attachmentId: body.attachmentId
+        });
       }
-      result.attachments.push({
-        filename: part.filename,
-        mimeType: part.mimeType,
-        size: body.size,
-        attachmentId: body.attachmentId
-      });
     }
-
+    
     firstPartProcessed = true;
   }
 


### PR DESCRIPTION
Useful when setting the response format to 'metadata' instead of default's 'full'